### PR TITLE
Шрифты

### DIFF
--- a/facebook.html
+++ b/facebook.html
@@ -4,6 +4,8 @@
         <title>Простые альтернативы Facebook, VK и Twitter &#8211; switching.social</title>
         <meta charset="utf-8">
         <meta name="generator" content="Self-coding">
+        <link rel="stylesheet" media="screen" href="https://fontlibrary.org/face/liberation-sans" type="text/css"/>
+        <link rel="stylesheet" media="screen" href="https://fontlibrary.org/face/comic-relief" type="text/css"/>
         <link rel="stylesheet" href="style.css" type="text/css">
         <meta name="viewport" content="width=device-width, initial-scale=1">
     </head>

--- a/hints-and-tips-for-making-friends.html
+++ b/hints-and-tips-for-making-friends.html
@@ -4,6 +4,8 @@
         <title>Подсказки и советы для начала работы в альтернативных социальных сетях &#8211; switching.social</title>
         <meta charset="utf-8">
         <meta name="generator" content="Self-coding">
+        <link rel="stylesheet" media="screen" href="https://fontlibrary.org/face/liberation-sans" type="text/css"/>
+        <link rel="stylesheet" media="screen" href="https://fontlibrary.org/face/comic-relief" type="text/css"/>
         <link rel="stylesheet" href="style.css" type="text/css">
         <meta name="viewport" content="width=device-width, initial-scale=1">
     </head>

--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
         <title>switching.social &#8211; Простые альтернативы популярным сайтам и приложениям</title>
         <meta charset="utf-8">
         <meta name="generator" content="Self-coding">
+        <link rel="stylesheet" media="screen" href="https://fontlibrary.org/face/liberation-sans" type="text/css"/>
+        <link rel="stylesheet" media="screen" href="https://fontlibrary.org/face/comic-relief" type="text/css"/>
         <link rel="stylesheet" href="style.css" type="text/css">
         <meta name="viewport" content="width=device-width, initial-scale=1">
     </head>

--- a/style.css
+++ b/style.css
@@ -31,16 +31,22 @@ hr {
 
 h1, h2 {
     margin: 20px 0;
+    font-family: 'ComicReliefRegular', fantasy;
+    font-weight: 900;
+    text-transform: uppercase;
+    font-size: 1.5rem;
 }
 
 p {
     margin: 20px 0;
     color: #717171;
+    font-family: 'LiberationSansRegular', 'Helvetica', sans-serif;
+    font-size: 21px;
 }
 
 a {
     margin: 20px 0;
-    color: #7B7B7B;
+    color: #111;
 }
 
 .footer a {
@@ -49,6 +55,7 @@ a {
 
 .footer p {
     color: #E6E6E6;
+    font-size: 1rem;
 }
 
 .content {


### PR DESCRIPTION
Добавлены подходящие бесплатные/свободные шрифты: Comic Relief и Liberation Sans (все загружаются с сайтика Font Library, который вроде не имеет PPolicy и залицензированы под [SIL Open Font License](https://scripts.sil.org/cms/scripts/page.php?site_id=nrsi&id=OFL)).
Помимо этого, были добавлены и запасные семьи шрифтов, которые _могут<sup>**[1]**</sup>_ быть установлены на устройстве пользователя.

<small>**[1]** ⸻ к сожалению, мне не удалось заметить что в стандартный набор шрифтов openSUSE и Chrome 74 входит что-то, что может заменить шрифт в заголовках.</small>